### PR TITLE
Update cloudinary_php package version + unit testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         "cloudinary/cloudinary_php": "dev-master"
     },
     "require-dev": {
-        "illuminate/support": ">=4.1.0"
+        "illuminate/support": ">=4.1.0",
+        "phpunit/phpunit": "4.*",
+        "mockery/mockery": "0.9.*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "teepluss/cloudinary",
+    "name": "jd/cloudinary",
     "description": "Cloudinary API wrapper for Laravel 4",
     "keywords": ["laravel", "laravel4", "cloudinary", "api", "image", "upload"],
     "homepage": "https://github.com/teepluss/laravel4-cloudinary",
@@ -13,10 +13,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "cloudinary/cloudinary_php": "1.0.11"
+        "cloudinary/cloudinary_php": "dev-master"
     },
     "require-dev": {
-        "illuminate/support": "4.1.x"
+        "illuminate/support": ">=4.1.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jd/cloudinary",
+    "name": "teepluss/cloudinary",
     "description": "Cloudinary API wrapper for Laravel 4",
     "keywords": ["laravel", "laravel4", "cloudinary", "api", "image", "upload"],
     "homepage": "https://github.com/teepluss/laravel4-cloudinary",

--- a/src/Teepluss/Cloudinary/CloudinaryServiceProvider.php
+++ b/src/Teepluss/Cloudinary/CloudinaryServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Teepluss\Cloudinary;
 
 use Illuminate\Support\ServiceProvider;
+use Cloudinary;
 
 class CloudinaryServiceProvider extends ServiceProvider {
 
@@ -30,7 +31,7 @@ class CloudinaryServiceProvider extends ServiceProvider {
 	{
 		$this->app['cloudinary'] = $this->app->share(function($app)
 		{
-			return new CloudinaryWrapper($app['config']);
+			return new CloudinaryWrapper($app['config'], new Cloudinary, new Cloudinary\Uploader);
 		});
 	}
 

--- a/src/Teepluss/Cloudinary/CloudinaryWrapper.php
+++ b/src/Teepluss/Cloudinary/CloudinaryWrapper.php
@@ -39,11 +39,11 @@ class CloudinaryWrapper {
      * @param  \Illuminate\Config\Repository $config
      * @return void
      */
-    public function __construct(Repository $config)
+    public function __construct(Repository $config, Cloudinary $cloudinary, Cloudinary\Uploader $uploader)
     {
-        $this->cloudinary = new Cloudinary;
+        $this->cloudinary = $cloudinary;
 
-        $this->uploader = new Cloudinary\Uploader;
+        $this->uploader = $uploader;
 
         $this->config = $config;
 

--- a/src/Teepluss/Cloudinary/CloudinaryWrapper.php
+++ b/src/Teepluss/Cloudinary/CloudinaryWrapper.php
@@ -82,7 +82,7 @@ class CloudinaryWrapper {
      * @param  array  $tags
      * @return CloudinaryWrapper
      */
-    public function upload($source, $publicId, $tags = array())
+    public function upload($source, $publicId = null, $tags = array())
     {
         $defaults = array(
             'public_id' => null,
@@ -161,9 +161,20 @@ class CloudinaryWrapper {
      * @param  array  $options
      * @return array
      */
-    public function destroy($publicId, $options = array())
+    public function destroyImage($publicId, $options = array())
     {
         return $this->getUploader()->destroy($publicId, $options);
+    }
+
+    /**
+     * Destroy images
+     * @param  array $publicIds
+     * @param  array $options
+     * @return array
+     */
+    public function destroyImages($publicIds, $options = array())
+    {
+        return $this->getUploader()->destroy($publicIds, $options);
     }
 
     /**
@@ -173,7 +184,7 @@ class CloudinaryWrapper {
      */
     public function delete($publicId, $options = array())
     {
-        $response = $this->destroy($publicId, $options);
+        $response = $this->destroyImage($publicId, $options);
 
         return (boolean) ($response['result'] == 'ok');
     }

--- a/src/Teepluss/Cloudinary/CloudinaryWrapper.php
+++ b/src/Teepluss/Cloudinary/CloudinaryWrapper.php
@@ -15,7 +15,7 @@ class CloudinaryWrapper {
     /**
      * Cloudinary uploader.
      *
-     * @var \Cloudinary\Uplaoder
+     * @var \Cloudinary\Uploader
      */
     protected $uploader;
 

--- a/src/Teepluss/Cloudinary/CloudinaryWrapper.php
+++ b/src/Teepluss/Cloudinary/CloudinaryWrapper.php
@@ -161,7 +161,7 @@ class CloudinaryWrapper {
      * @param  array  $options
      * @return array
      */
-    public function destroyImage($publicId, $options = array())
+    public function destroy($publicId, $options = array())
     {
         return $this->getUploader()->destroy($publicId, $options);
     }
@@ -184,7 +184,7 @@ class CloudinaryWrapper {
      */
     public function delete($publicId, $options = array())
     {
-        $response = $this->destroyImage($publicId, $options);
+        $response = $this->destroy($publicId, $options);
 
         return (boolean) ($response['result'] == 'ok');
     }

--- a/tests/CloudinaryWrapperTest.php
+++ b/tests/CloudinaryWrapperTest.php
@@ -80,7 +80,7 @@ class CloudinaryWrapperTest extends \PHPUnit_Framework_TestCase
         $this->uploader->shouldReceive('destroy')->with($pid, array())->once();
 
         // when
-        $this->cloudinary_wrapper->destroyImage($pid);
+        $this->cloudinary_wrapper->destroy($pid);
     }
 
     /** @test */

--- a/tests/CloudinaryWrapperTest.php
+++ b/tests/CloudinaryWrapperTest.php
@@ -1,0 +1,140 @@
+<?php namespace Teepluss\Cloudinary\Test;
+
+use Teepluss\Cloudinary\CloudinaryWrapper;
+use Mockery as m;
+
+class CloudinaryWrapperTest extends \PHPUnit_Framework_TestCase
+{   
+    public function setUp()
+    {
+        $this->config = m::mock('Illuminate\Config\Repository');
+        $this->cloudinary = m::mock('Cloudinary');
+        $this->uploader = m::mock('Cloudinary\Uploader');
+
+        $this->config->shouldReceive('get')->once()->with('cloudinary::cloudName')->andReturn('cloudName');
+        $this->config->shouldReceive('get')->once()->with('cloudinary::apiKey')->andReturn('apiKey');
+        $this->config->shouldReceive('get')->once()->with('cloudinary::apiSecret')->andReturn('apiSecret');
+
+        $this->cloudinary->shouldReceive('config')->once();
+
+        $this->cloudinary_wrapper = new CloudinaryWrapper($this->config, $this->cloudinary, $this->uploader);
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    /** @test */
+    public function it_should_set_uploaded_result_when_uploading_picture()
+    {
+        // given
+        $filename = 'filename';
+        $defaults_options = [
+            'public_id' => null,
+            'tags'      => array()
+        ];
+
+        $expected_result = ['public_id' => '123456789'];
+
+        $this->uploader->shouldReceive('upload')->once()->with($filename, $defaults_options)->andReturn($expected_result);
+
+        // when
+        $this->cloudinary_wrapper->upload($filename);
+
+        // then
+        $result = $this->cloudinary_wrapper->getResult();
+        $this->assertEquals($expected_result, $result);
+    }
+
+    /** @test */
+    public function it_should_returns_image_url_when_calling_show()
+    {
+        // given
+        $filename = 'filename';
+        $this->config->shouldReceive('get')->with('cloudinary::scaling')->once()->andReturn(array());
+        $this->cloudinary->shouldReceive('cloudinary_url')->once()->with($filename, array());
+
+        // when
+        $this->cloudinary_wrapper->show($filename);
+    }
+
+    /** @test */
+    public function it_should_call_api_rename_when_calling_rename()
+    {
+        // given
+        $from = 'from';
+        $to = 'to';
+
+        $this->uploader->shouldReceive('rename')->with($from, $to, array())->once();
+
+        // when
+        $this->cloudinary_wrapper->rename($from, $to);
+    }
+
+    /** @test */
+    public function it_should_call_api_destroy_when_calling_destroy_image()
+    {
+        // given
+        $pid = 'pid';
+        $this->uploader->shouldReceive('destroy')->with($pid, array())->once();
+
+        // when
+        $this->cloudinary_wrapper->destroyImage($pid);
+    }
+
+    /** @test */
+    public function it_should_call_api_destroy_with_array_of_public_ids()
+    {
+        // given
+        $pids = ['pid1', 'pid2'];
+        $this->uploader->shouldReceive('destroy')->with($pids, array())->once();
+
+        // when
+        $this->cloudinary_wrapper->destroyImages($pids);
+    }
+
+    /** @test */
+    public function verify_delete_alias()
+    {
+        // given
+        $pid = 'pid';
+        $this->uploader->shouldReceive('destroy')->with($pid, array())->once();
+
+        // when
+        $this->cloudinary_wrapper->delete($pid);
+    }
+
+    /** @test */
+    public function it_should_call_api_add_tag_when_calling_add_tag()
+    {
+        $pids = ['pid1', 'pid2'];
+        $tag = 'tag';
+
+        $this->uploader->shouldReceive('add_tag')->once()->with($tag, $pids, array());
+
+        $this->cloudinary_wrapper->addTag($tag, $pids);
+    }
+
+    /** @test */
+    public function it_should_call_api_remove_tag_when_calling_add_tag()
+    {
+        $pids = ['pid1', 'pid2'];
+        $tag = 'tag';
+
+        $this->uploader->shouldReceive('remove_tag')->once()->with($tag, $pids, array());
+
+        $this->cloudinary_wrapper->removeTag($tag, $pids);
+    }
+
+        /** @test */
+    public function it_should_call_api_rename_tag_when_calling_add_tag()
+    {
+        $pids = ['pid1', 'pid2'];
+        $tag = 'tag';
+
+        $this->uploader->shouldReceive('replace_tag')->once()->with($tag, $pids, array());
+
+        $this->cloudinary_wrapper->replaceTag($tag, $pids);
+    }
+}


### PR DESCRIPTION
- Update cloudinary_php package version to dev-master
- Make publicId optional in upload method to be able to have a generated public id from the api.
- Add method destroyImages to remove images from cloudinary, several images at once.
- Inject Cloudinary and Cloudinary\Uploader when creating wrapper in provider
- Add basic unit tests for wrapper
