### PR TITLE
New Cloudy::check() method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Cloudy::upload($_FILES['tmp_name'], 'custom_public_name', $tags);
 //Cloudy::upload('http://domain.com/remote.jpg', 'custom_public_name', $tags);
 ~~~
 
+Verify an image is available.
+~~~php
+// Simply if the image is on the service
+Cloudy::check('custom_public_name');
+// Or even with your custom parameters (this could be used to validate them, if there is a problem with your parameters, we log it using Laravel Log Facade.)
+Cloudy::check('custom_public_name', array('width' => 150, 'height' => 150, 'crop' => 'fit', 'radius' => 20));
+~~~
+
 Display an image.
 ~~~php
 Cloudy::show('custom_public_name', array('width' => 150, 'height' => 150, 'crop' => 'fit', 'radius' => 20));

--- a/src/Teepluss/Cloudinary/CloudinaryServiceProvider.php
+++ b/src/Teepluss/Cloudinary/CloudinaryServiceProvider.php
@@ -18,7 +18,14 @@ class CloudinaryServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('teepluss/cloudinary');
+		$enabled = $this->app->share(function($app)
+		{
+			return $app['config']->get('cloudinary::enabled', false);
+		});
+		
+		if ($enabled) {
+			$this->package('teepluss/cloudinary');
+		}
 	}
 
 	/**

--- a/src/Teepluss/Cloudinary/CloudinaryWrapper.php
+++ b/src/Teepluss/Cloudinary/CloudinaryWrapper.php
@@ -2,6 +2,7 @@
 
 use Cloudinary;
 use Illuminate\Config\Repository;
+use Illuminate\Support\Facades\Log;
 
 class CloudinaryWrapper {
 
@@ -117,6 +118,29 @@ class CloudinaryWrapper {
     public function getPublicId()
     {
         return $this->uploadedResult['public_id'];
+    }
+
+    /**
+     * Check if the image is available with requested parameters.
+     *
+     * @param  string $publicId
+     * @param  array  $options
+     * @return boolean
+     */
+    public function check($publicId, $options = array())
+    {
+        $url     = $this->show($publicId, $options);
+        $headers = get_headers($url, true);
+
+        if (str_contains($headers[0], '200')) {
+            return true;
+        }
+        else {
+            if (isset($headers['X-Cld-Error'])) {
+                Log::warning('Cloudinary API: ' . $headers['X-Cld-Error']);
+            }
+            return false;
+        }
     }
 
     /**

--- a/src/Teepluss/Cloudinary/CloudinaryWrapper.php
+++ b/src/Teepluss/Cloudinary/CloudinaryWrapper.php
@@ -129,6 +129,10 @@ class CloudinaryWrapper {
      */
     public function check($publicId, $options = array())
     {
+        if (!$publicId) {
+            return false;
+        }
+        
         $url     = $this->show($publicId, $options);
         $headers = get_headers($url, true);
 

--- a/src/Teepluss/Cloudinary/CloudinaryWrapper.php
+++ b/src/Teepluss/Cloudinary/CloudinaryWrapper.php
@@ -51,7 +51,8 @@ class CloudinaryWrapper {
         $this->cloudinary->config(array(
             'cloud_name' => $this->config->get('cloudinary::cloudName'),
             'api_key'    => $this->config->get('cloudinary::apiKey'),
-            'api_secret' => $this->config->get('cloudinary::apiSecret')
+            'api_secret' => $this->config->get('cloudinary::apiSecret'),
+            'secure'     => $this->config->get('cloudinary::secure', false),
         ));
     }
 

--- a/src/Teepluss/Cloudinary/CloudinaryWrapper.php
+++ b/src/Teepluss/Cloudinary/CloudinaryWrapper.php
@@ -130,19 +130,25 @@ class CloudinaryWrapper {
      */
     public function check($publicId, $options = array())
     {
-        if (!$publicId) {
+        if ( ! $publicId) {
             return false;
         }
-        
-        $url     = $this->show($publicId, $options);
-        $headers = get_headers($url, true);
 
-        if (str_contains($headers[0], '200')) {
+        $headers = false;
+        $url     = $this->show($publicId, $options);
+
+        try {
+            $headers = get_headers($url, true);
+        } catch (\Exception $e) {
+            Log::warning('Cloudinary API Error: ' . $e->getMessage());
+        }
+
+        if ($headers && str_contains($headers[0], '200')) {
             return true;
         }
         else {
             if (isset($headers['X-Cld-Error'])) {
-                Log::warning('Cloudinary API: ' . $headers['X-Cld-Error']);
+                Log::warning('Cloudinary API Error: ' . $headers['X-Cld-Error']);
             }
             return false;
         }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,6 +12,8 @@ return array(
     |
     */
 
+    'enabled'    => false,
+
     'cloudName'  => '',
     'baseUrl'    => '',
     'secureUrl'  => '',

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -15,6 +15,7 @@ return array(
     'cloudName'  => '',
     'baseUrl'    => '',
     'secureUrl'  => '',
+    'secure'     => false,
     'apiBaseUrl' => '',
     'apiKey'     => '',
     'apiSecret'  => '',


### PR DESCRIPTION
Add Cloudy::check() in order to verify if an image is available. This function accepts the same parameters as the show() function. If Cloudinary API returns a response without a 200 HTTP Status code, we log the error message using Laravel Log::warning().
Updated README.md

BONUS:
Add ability to disable the package. Very useful on specific environments where you don't want to use Cloudinary.
